### PR TITLE
Use CMake relative destination directories, instead of hardcoding dirs

### DIFF
--- a/mpicc.in
+++ b/mpicc.in
@@ -8,19 +8,19 @@
 # We choose to behave like OpenMPI in this respect.
 
 if [ "x$1" = "x-showme:compile" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@'
     exit 0
 elif [ "x$1" = "x-showme:link" ]; then
-    echo '-L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 elif [ "x$1" = "x-showme" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 fi
 
 # if [ "x$1" = "x-compile-info" -o "x$1" = "x-link-info" ]; then
-#     echo ${MPITRAMPOLINE_CC:-cc} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+#     echo ${MPITRAMPOLINE_CC:-cc} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl
 #     exit 0
 # fi
 
-exec ${MPITRAMPOLINE_CC:-cc} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+exec ${MPITRAMPOLINE_CC:-cc} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl

--- a/mpicxx.in
+++ b/mpicxx.in
@@ -8,19 +8,19 @@
 # We choose to behave like OpenMPI in this respect.
 
 if [ "x$1" = "x-showme:compile" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@'
     exit 0
 elif [ "x$1" = "x-showme:link" ]; then
-    echo '-L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 elif [ "x$1" = "x-showme" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 fi
 
 # if [ "x$1" = "x-compile-info" -o "x$1" = "x-link-info" ]; then
-#     echo ${MPITRAMPOLINE_CXX:-c++} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+#     echo ${MPITRAMPOLINE_CXX:-c++} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl
 #     exit 0
 # fi
 
-exec ${MPITRAMPOLINE_CXX:-c++} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+exec ${MPITRAMPOLINE_CXX:-c++} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl

--- a/mpifc.in
+++ b/mpifc.in
@@ -8,19 +8,19 @@
 # We choose to behave like OpenMPI in this respect.
 
 if [ "x$1" = "x-showme:compile" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@'
     exit 0
 elif [ "x$1" = "x-showme:link" ]; then
-    echo '-L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 elif [ "x$1" = "x-showme" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 fi
 
 # if [ "x$1" = "x-compile-info" -o "x$1" = "x-link-info" ]; then
-#     echo ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+#     echo ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl
 #     exit 0
 # fi
 
-exec ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+exec ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl

--- a/mpifort.in
+++ b/mpifort.in
@@ -8,19 +8,19 @@
 # We choose to behave like OpenMPI in this respect.
 
 if [ "x$1" = "x-showme:compile" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@'
     exit 0
 elif [ "x$1" = "x-showme:link" ]; then
-    echo '-L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 elif [ "x$1" = "x-showme" ]; then
-    echo '-I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib -lmpitrampoline -ldl'
+    echo '-I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ -lmpitrampoline -ldl'
     exit 0
 fi
 
 # if [ "x$1" = "x-compile-info" -o "x$1" = "x-link-info" ]; then
-#     echo ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+#     echo ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl
 #     exit 0
 # fi
 
-exec ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/include -L@CMAKE_INSTALL_PREFIX@/lib "$@" -lmpitrampoline -ldl
+exec ${MPITRAMPOLINE_FC:-gfortran} -I@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@ -L@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@ "$@" -lmpitrampoline -ldl


### PR DESCRIPTION
This is in particular useful for libraries on Windows, which should be installed
under `bin/`, not `lib/`.  See [CMake
documentation](https://cmake.org/cmake/help/latest/command/install.html) for
more information about these variables.