### PR TITLE
Fix MPI_IN_PLACE sentinel detection in Fortran wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,12 @@ else()
 endif()
 
 if(ENABLE_FORTRAN)
-  set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include)
+  # Use CMAKE_CURRENT_BINARY_DIR (not CMAKE_BINARY_DIR) so that the path
+  # resolves correctly when MPItrampoline is included as a subproject via
+  # FetchContent.  CMAKE_BINARY_DIR always points to the top-level build
+  # tree, whereas CMAKE_CURRENT_BINARY_DIR follows the currently processed
+  # CMakeLists.txt.
+  set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 endif()
 
 include(CMakePackageConfigHelpers)
@@ -299,16 +304,21 @@ configure_file(MPItrampoline.pc.in MPItrampoline.pc @ONLY)
 configure_file(mpi-c.pc.in mpi-c.pc @ONLY)
 configure_file(mpi-cxx.pc.in mpi-cxx.pc @ONLY)
 configure_file(mpi-fort.pc.in mpi-fort.pc @ONLY)
+# Use CMAKE_CURRENT_BINARY_DIR (not CMAKE_BINARY_DIR) for the generated .pc
+# files so that the paths resolve correctly when MPItrampoline is included as
+# a subproject via FetchContent.  CMAKE_BINARY_DIR always points to the
+# top-level build tree, whereas CMAKE_CURRENT_BINARY_DIR follows the currently
+# processed CMakeLists.txt.
 install(
   FILES
-  ${CMAKE_BINARY_DIR}/MPItrampoline.pc
-  ${CMAKE_BINARY_DIR}/mpi-c.pc
-  ${CMAKE_BINARY_DIR}/mpi-cxx.pc
-  ${CMAKE_BINARY_DIR}/mpi-fort.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/MPItrampoline.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/mpi-c.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/mpi-cxx.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/mpi-fort.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 install(
-  FILES ${CMAKE_BINARY_DIR}/mpi-c.pc
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/mpi-c.pc
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 


### PR DESCRIPTION
Enable sentinel replacement in generated Fortran wrapper functions.

The Fortran-level `MPI_IN_PLACE` (Cray pointer from `mpif.h`, backed by `mpiabi_in_place_ptr_`) was passed through to the ABI function without conversion to the C-level `MPI_IN_PLACE` constant. The wrapped MPI library did not recognise the Fortran sentinel, causing `MPI_Allreduce` (and other collectives) with `MPI_IN_PLACE` to silently return zeros.

1/ The fix adds sentinel checks in the generated wrappers: when the `sendbuf` pointer equals `mpiabi_in_place_ptr_`, it is replaced with the C-level `MPI_IN_PLACE` before forwarding to the ABI function.  

2/ Refactors the three duplicated sentinel-check code blocks into a single `generate_fortran_sentinel_checks()` helper and updates the `MPI_STATUS_IGNORE` replacement to use compatible pointer casts.

Note that this contains the CMake changes from pull request from #52 
